### PR TITLE
KB-7057 | Q6 | Nation Learning Week | API for event state update

### DIFF
--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/Util.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/Util.java
@@ -75,6 +75,10 @@ public final class Util {
     dbInfoMap.put(JsonKey.ENROLLMENT_BATCH_DB, getDbInfoObject(COURSE_KEY_SPACE_NAME, "enrollment_batch_lookup"));
     dbInfoMap.put(JsonKey.CONTENT_HIERARCHY_STORE_DB, getDbInfoObject(ProjectUtil.getConfigValue(JsonKey.CONTENT_HIERARCHY_STORE_KEY_SPACE_NAME), "content_hierarchy"));
     dbInfoMap.put(JsonKey.USER_KARMA_POINTS_DB, getDbInfoObject(KEY_SPACE_NAME, "user_karma_points_summary"));
+    dbInfoMap.put(
+            JsonKey.LEARNER_EVENT_DB, getDbInfoObject(COURSE_KEY_SPACE_NAME, "user_event_consumption"));
+    dbInfoMap.put(
+            JsonKey.LEARNER_ENROLMENT_DB, getDbInfoObject(COURSE_KEY_SPACE_NAME, "user_event_enrolments"));
   }
 
   /**

--- a/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
+++ b/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
@@ -1143,5 +1143,8 @@ public final class JsonKey {
   public static final String END_DATE_BATCH = "end_date";
   public static final String ADD_EXTRA_HOURS_MINS = "addExtraHrsAndMins.start_date_end_date";
   public static final String STANDALONE_ASSESSMENT ="Standalone Assessment";
+  public static final String EVENT_ID = "eventId";
+  public static final String LEARNER_EVENT_DB = "learnerEvent_db";
+  public static final String LEARNER_ENROLMENT_DB = "learnerEnrolment_db";
   private JsonKey() {}
 }

--- a/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/responsecode/ResponseCode.java
+++ b/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/responsecode/ResponseCode.java
@@ -842,6 +842,12 @@ public enum ResponseCode {
   notOpenBatch(
           ResponseMessage.Key.NOT_OPEN_BATCH,
           ResponseMessage.Message.NOT_OPEN_BATCH),
+  eventIdRequired(
+          ResponseMessage.Key.EVENT_ID_MISSING_ERROR,
+          ResponseMessage.Message.EVENT_ID_MISSING_ERROR),
+  eventIdRequiredError(
+          ResponseMessage.Key.EVENT_ID_MISSING, ResponseMessage.Message.EVENT_ID_MISSING),
+
 
   accessDeniedToEnrolOrUnenrolCourse(ResponseMessage.Key.USER_DOES_NOT_HAVE_ACCESS,ResponseMessage.Message.USER_DOES_NOT_HAVE_ACCESS),
   OK(200),

--- a/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/responsecode/ResponseMessage.java
+++ b/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/responsecode/ResponseMessage.java
@@ -463,6 +463,8 @@ public interface ResponseMessage {
     String CURRENT_BATCH_SIZE_PARAMETER = "Request body has invalid/missing parameter 'currentBatchSize' in batchAttributes.";
     String COURSE_DOES_NOT_HAVE_BATCH = "Course doesn't have any batch.";
     String NOT_OPEN_BATCH ="Not an open batch";
+    String EVENT_ID_MISSING_ERROR = "Please provide event id.";
+    String EVENT_ID_MISSING = "Event id is mandatory.";
   }
 
   interface Key {
@@ -854,5 +856,7 @@ public interface ResponseMessage {
     String CURRENT_BATCH_SIZE_INVALID =  "INVALID_FIELD_CURRENT_BATCH_SIZE";
     String COURSE_DOES_NOT_HAVE_BATCH = "COURSE_DOES_NOT_HAVE_BATCH";
     String NOT_OPEN_BATCH ="NOT_OPEN_BATCH";
+    String EVENT_ID_MISSING_ERROR = "EVENT_ID_REQUIRED_ERROR";
+    String EVENT_ID_MISSING = "EVENT_ID_REQUIRED_ERROR";
   }
 }

--- a/service/app/util/RequestValidator.java
+++ b/service/app/util/RequestValidator.java
@@ -1012,4 +1012,80 @@ public final class RequestValidator {
         ResponseCode.getResponse(errorCode).getErrorMessage(),
         ERROR_CODE);
   }
+
+  public static void validateUpdateEvent(Request contentRequestDto) {
+    List<Map<String, Object>> list =
+            (List<Map<String, Object>>) (contentRequestDto.getRequest().get(JsonKey.EVENTS));
+    if (CollectionUtils.isNotEmpty(list)) {
+      for (Map<String, Object> map : list) {
+        if (null != map.get(JsonKey.LAST_UPDATED_TIME)) {
+          boolean bool =
+                  ProjectUtil.isDateValidFormat(
+                          "yyyy-MM-dd HH:mm:ss:SSSZ", (String) map.get(JsonKey.LAST_UPDATED_TIME));
+          if (!bool) {
+            throw new ProjectCommonException(
+                    ResponseCode.dateFormatError.getErrorCode(),
+                    ResponseCode.dateFormatError.getErrorMessage(),
+                    ERROR_CODE);
+          }
+        }
+        if (null != map.get(JsonKey.LAST_COMPLETED_TIME)) {
+          boolean bool =
+                  ProjectUtil.isDateValidFormat(
+                          "yyyy-MM-dd HH:mm:ss:SSSZ", (String) map.get(JsonKey.LAST_COMPLETED_TIME));
+          if (!bool) {
+            throw new ProjectCommonException(
+                    ResponseCode.dateFormatError.getErrorCode(),
+                    ResponseCode.dateFormatError.getErrorMessage(),
+                    ERROR_CODE);
+          }
+        }
+        if (map.containsKey(JsonKey.EVENT_ID)) {
+
+          if (null == map.get(JsonKey.EVENT_ID)) {
+            throw new ProjectCommonException(
+                    ResponseCode.eventIdRequired.getErrorCode(),
+                    ResponseCode.eventIdRequiredError.getErrorMessage(),
+                    ERROR_CODE);
+          }
+          if (ProjectUtil.isNull(map.get(JsonKey.STATUS))) {
+            throw new ProjectCommonException(
+                    ResponseCode.contentStatusRequired.getErrorCode(),
+                    ResponseCode.contentStatusRequired.getErrorMessage(),
+                    ERROR_CODE);
+          }
+
+        } else {
+          throw new ProjectCommonException(
+                  ResponseCode.eventIdRequired.getErrorCode(),
+                  ResponseCode.eventIdRequiredError.getErrorMessage(),
+                  ERROR_CODE);
+        }
+      }
+    }
+
+    // Validation for enrolment sync
+    if (CollectionUtils.isEmpty(list)) {
+      contentRequestDto.getRequest().put(JsonKey.EVENT_ID, contentRequestDto.getOrDefault(JsonKey.EVENT_ID, ""));
+      if (StringUtils.isBlank((String) contentRequestDto.getOrDefault(JsonKey.EVENT_ID, ""))) {
+        throw new ProjectCommonException(
+                ResponseCode.eventIdRequired.getErrorCode(),
+                ResponseCode.eventIdRequiredError.getErrorMessage(),
+                ERROR_CODE);
+      }
+      if (StringUtils.isBlank((String) contentRequestDto.getOrDefault(JsonKey.BATCH_ID, ""))) {
+        throw new ProjectCommonException(
+                ResponseCode.courseBatchIdRequired.getErrorCode(),
+                ResponseCode.courseBatchIdRequired.getErrorMessage(),
+                ERROR_CODE);
+      }
+
+      if (StringUtils.isBlank((String) contentRequestDto.getOrDefault(JsonKey.USER_ID, ""))) {
+        throw new ProjectCommonException(
+                ResponseCode.userIdRequired.getErrorCode(),
+                ResponseCode.userIdRequired.getErrorMessage(),
+                ERROR_CODE);
+      }
+    }
+  }
 }

--- a/service/conf/routes
+++ b/service/conf/routes
@@ -100,3 +100,5 @@ DELETE  /v1/eventset/discard/:id            @controllers.eventmanagement.EventSe
 DELETE  /v1/event/discard/:id               @controllers.eventmanagement.EventController.discard(id: String, request: play.mvc.Http.Request)
 POST    /v1/user/event/state/read           @controllers.eventmanagement.EventConsumptionController.getUserEventState(request: play.mvc.Http.Request)
 PATCH   /v1/user/event/state/update     	@controllers.eventmanagement.EventConsumptionController.updateUserEventState(request: play.mvc.Http.Request)
+
+PATCH    /v1/event/state/update     	@controllers.LearnerController.updateEventState(request: play.mvc.Http.Request)


### PR DESCRIPTION
1. Created a end point for event state update which is similar to the content state update.
2. While replicating have removed the assessment as contents only events will be considered.
3. Have made changes to the table names which were used i.e event_batch,user_event_consumption,user_event_enrolments.
3. Kafka topic event generation would need enhancements.
4. contentId is updated with eventId  & courseId is removed in the service methods.
