### PR TITLE
"KAR-829:Return only active enrolments in the response in all cases"

### DIFF
--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/CourseEnrolmentActor.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/CourseEnrolmentActor.scala
@@ -223,11 +223,7 @@ class CourseEnrolmentActor @Inject()(@Named("course-batch-notification-actor") c
     def getActiveEnrollments(userId: String, courseIdList: java.util.List[String], requestContext: RequestContext): java.util.List[java.util.Map[String, AnyRef]] = {
         val enrolments: java.util.List[java.util.Map[String, AnyRef]] = userCoursesDao.listEnrolments(requestContext, userId, courseIdList);
         if (CollectionUtils.isNotEmpty(enrolments)) {
-            if (isRetiredCoursesIncludedInEnrolList) {
-                enrolments.toList.asJava
-            } else {
-                enrolments.filter(e => e.getOrDefault(JsonKey.ACTIVE, false.asInstanceOf[AnyRef]).asInstanceOf[Boolean]).toList.asJava
-            }
+            enrolments.filter(e => e.getOrDefault(JsonKey.ACTIVE, false.asInstanceOf[AnyRef]).asInstanceOf[Boolean]).toList.asJava
         } else
             new util.ArrayList[java.util.Map[String, AnyRef]]()
     }


### PR DESCRIPTION
When we fetch all the enrollments using the flag "retiredCoursesEnabled=true," the response currently includes both active and inactive enrollments. However, we should not display inactive enrollments for users who have been removed from any batches of the BP or Invite Only program, as they cannot take any further action on these. To address this issue, I have added a filter to return only active enrollments in the enrollment list API.