### PR TITLE
KB-7067 | Learners enrolled count not updating for Moderated program, Invite only program, and Invite only assessment when any learner is added /removed via manage learner invitation in the Batch details page

### DIFF
--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/actors/coursebatch/dao/impl/UserCoursesDaoImpl.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/actors/coursebatch/dao/impl/UserCoursesDaoImpl.java
@@ -246,7 +246,8 @@ public class UserCoursesDaoImpl implements UserCoursesDao {
       }
     }
     result.put(JsonKey.CURRENT_OFFSET, (Integer) request.get(JsonKey.CURRENT_OFFSET));
-    result.put(JsonKey.COUNT, count);
+    //Only active users will be returned.
+    result.put(JsonKey.COUNT, userList.size());
     result.put(JsonKey.PARTICIPANTS, userList);
     return result;
   }


### PR DESCRIPTION
1. Currently as per the exisiting functionality we are returning all the users active+inactive so the search response returns the total users as the count.
2. As per the regression defect raised we need to return only the active users.
