### PR TITLE
Cbrelease 4.8.28 (#250)

### DIFF
--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/ExtendedCourseEnrollmentActor.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/ExtendedCourseEnrollmentActor.scala
@@ -459,11 +459,15 @@ class ExtendedCourseEnrollmentActor @Inject()(@Named("course-batch-notification-
     if (CollectionUtils.isNotEmpty(enrolments)) {
       enrolments = enrolments.filter(e => e.getOrDefault(JsonKey.ACTIVE, false.asInstanceOf[AnyRef]).asInstanceOf[Boolean]).toList.asJava
       // Map status strings to their integer values, ignoring unknown statuses
-      if (status != null) {
+      if (status != null && status.nonEmpty) {
         val statusValues: Set[Int] = status.flatMap(s => statusMap.get(s)).toSet
         if (statusValues.nonEmpty) {
           enrolments = enrolments
-            .filter(e => statusValues.contains(e.getOrDefault(JsonKey.STATUS, (-1).asInstanceOf[AnyRef]).asInstanceOf[Int]))
+            .filter { e =>
+              val enrolStatus = e.getOrDefault(JsonKey.STATUS, (-1).asInstanceOf[AnyRef]).asInstanceOf[Int]
+              if (statusValues.contains(1)) enrolStatus != 2
+              else statusValues.contains(enrolStatus)
+            }
             .toList
             .asJava
         }

--- a/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
+++ b/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
@@ -1251,6 +1251,7 @@ public final class JsonKey {
   public static final String ERROR_MULTILINGUAL_BASE_LANG_NOT_FOUND = "Base language content not found or not live in languageMapV1 for multilingual course.";
   public static final String IS_BASE_LANGUAGE = "isBaseLang";
   public static final String LANGUAGE_NOT_FOUND_IN_CONTENT = "Language not found in content metadata.";
+  public static final String ALLOWED_PRIMARY_CATEGORIES = "status_update_allowed_primary_category";
   public static final String SUNBIRD_PRIVATE_SEARCH_USER_API = "sunbird_private_search_user_api";
   public static final String USER_ID_REQ = "user_id";
   public static final String FIRST_NAME_KEY = "first_name";

--- a/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/resources/externalresource.properties
+++ b/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/resources/externalresource.properties
@@ -246,6 +246,7 @@ content_ttl=3600
 participants_ttl=14400
 participants_fetch_size=100
 kafka_topics_instruction_v2=local.coursebatch.job.request.v2
+status_update_allowed_primary_category=Offline Session,Course Assessment
 sunbird_private_search_user_api=/private/user/v1/search
 notification_wrapper_api_host=http://cb-notification-wrapper-service:8081
 notification_wrapper_api_endpoint=/notifications/create

--- a/service/app/controllers/courseenrollment/ExtendedCourseEnrollmentController.java
+++ b/service/app/controllers/courseenrollment/ExtendedCourseEnrollmentController.java
@@ -166,7 +166,7 @@ public class ExtendedCourseEnrollmentController extends BaseController {
                     logger.info( ((Request) request).getRequestContext(), " CourseEnrollmentController : Request for enroll recieved via Blended Program admin enroll, UserId : "+  userId +", courseId : "+courseId+ ", batchId:"+batchId);
                     validator.validateEnrollCourse(req);
                     //call validateEnrollmentCriteriaMethod validateEnrolmentCriteria
-                    validator.validateEnrolmentCriteria(req, false, false);
+                    validator.validateEnrolmentCriteria(req, true, true);
 
                     return null;
                 },

--- a/service/app/util/ExtendedRequestValidator.java
+++ b/service/app/util/ExtendedRequestValidator.java
@@ -4,22 +4,30 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.sunbird.cassandra.CassandraOperation;
 import org.sunbird.common.Constants;
 import org.sunbird.common.exception.ProjectCommonException;
+import org.sunbird.common.models.response.Response;
 import org.sunbird.common.models.util.JsonKey;
 import org.sunbird.common.models.util.LoggerUtil;
 import org.sunbird.common.models.util.ProjectUtil;
 import org.sunbird.common.request.Request;
 import org.sunbird.common.responsecode.ResponseCode;
+import org.sunbird.helper.ServiceFactory;
 import org.sunbird.learner.util.ContentCacheHandlerV2;
+import org.sunbird.learner.util.ExtendedUtil;
 
 import java.util.*;
+
+import static org.sunbird.common.request.orgvalidator.BaseOrgRequestValidator.ERROR_CODE;
 
 public class ExtendedRequestValidator {
 
     private static final int ERROR_CODE = ResponseCode.CLIENT_ERROR.getResponseCode();
     public static LoggerUtil logger = new LoggerUtil(RequestValidator.class);
     private static ObjectMapper mapper = new ObjectMapper();
+    private static CassandraOperation cassandraOperation =  ServiceFactory.getInstance();
+    private static final ExtendedUtil.DbInfo enrolmentDBInfo = ExtendedUtil.dbInfoMap.get(JsonKey.LEARNER_COURSE_DB);
 
 
     /**
@@ -71,66 +79,71 @@ public class ExtendedRequestValidator {
                                 ResponseCode.contentStatusRequired.getErrorMessage(),
                                 ERROR_CODE);
                     }
-
                 } else {
                     throw new ProjectCommonException(
                             ResponseCode.contentIdRequired.getErrorCode(),
                             ResponseCode.contentIdRequiredError.getErrorMessage(),
                             ERROR_CODE);
                 }
-                String courseId = map.containsKey(JsonKey.COURSE_ID) ? JsonKey.COURSE_ID : JsonKey.COLLECTION_ID;
-                map.put(JsonKey.COURSE_ID, map.get(courseId));
+
+                map.put(JsonKey.COURSE_ID, map.containsKey(JsonKey.COURSE_ID)
+                        ? map.get(JsonKey.COURSE_ID)
+                        : map.get(JsonKey.COLLECTION_ID));
+
                 if (StringUtils.isBlank((String) map.get(JsonKey.COURSE_ID))) {
                     throw new ProjectCommonException(
                             ResponseCode.courseIdRequired.getErrorCode(),
                             ResponseCode.courseIdRequiredError.getErrorMessage(),
                             ERROR_CODE);
-                } else if (isProgramConsumptionAccepted((String) map.get(JsonKey.COURSE_ID), contentId)){
+                }
+                Map<String, Object> courseDetails = getCourseContent((String) map.get(JsonKey.COURSE_ID));
+                if (isProgramConsumptionAccepted((String) courseDetails.get(JsonKey.COURSECATEGORY), contentId,  (Boolean) courseDetails.get("cumulativeTracking"))) {
                     throw new ProjectCommonException(
                             ResponseCode.invalidProgramId.getErrorCode(),
                             ResponseCode.invalidProgramId.getErrorMessage(),
                             ERROR_CODE);
                 }
-
-                Map<String, Object> courseDetails = getCourseContent(StringUtils.isNotBlank((String) map.get(JsonKey.COURSE_ID))
-                        ? (String) map.get(JsonKey.COURSE_ID)
-                        : (String) map.get(JsonKey.COLLECTION_ID));
-                String category = (String) courseDetails.get(JsonKey.COURSECATEGORY);
-                if (StringUtils.equalsIgnoreCase(Constants.MULTI_LINGUAL_COURSE, category))
-                {
-                        throw new ProjectCommonException(
-                                ResponseCode.languageRequired.getErrorCode(),
-                               JsonKey.MULTILINGUAL_COURSE_PROGRESS_UPDATE_ERROR,
-                                ERROR_CODE);
+                if (StringUtils.equalsIgnoreCase(Constants.MULTI_LINGUAL_COURSE, (String) courseDetails.get(JsonKey.COURSECATEGORY))) {
+                    throw new ProjectCommonException(
+                            ResponseCode.languageRequired.getErrorCode(),
+                            JsonKey.MULTILINGUAL_COURSE_PROGRESS_UPDATE_ERROR,
+                            ERROR_CODE);
                 }
-                Map<String, Object> courseContent = getCourseContent(contentId);
-                List<String> allowedLanguages = (List<String>) courseContent.get(JsonKey.LANGUAGE);
+
+                Map<String, Object> languageMapV1 = (Map<String, Object>) courseDetails.get(JsonKey.LANGUAGE_MAP);
+
                 String incomingLanguage = (String) map.get(JsonKey.LANGUAGE);
+                Map<String, Object> enrolmentData = fetchEnrolmentData(
+                        (String) contentRequestDto.getRequest().get(JsonKey.USER_ID),
+                        (String) map.get(JsonKey.COURSE_ID),
+                        (String) map.get(JsonKey.BATCH_ID),
+                        contentRequestDto
+                );
+                String recentLanguage = (String) enrolmentData.get(JsonKey.RECENT_LANGUAGE);
+
                 if (StringUtils.isBlank(incomingLanguage)) {
-                    if (CollectionUtils.isNotEmpty(allowedLanguages)) {
-                        map.put(JsonKey.LANGUAGE, allowedLanguages.get(0).toLowerCase());
-                    } else {
+                    if (StringUtils.isBlank(recentLanguage)) {
                         throw new ProjectCommonException(
                                 ResponseCode.languageRequired.getErrorCode(),
                                 ResponseCode.languageRequired.getErrorMessage(),
                                 ERROR_CODE
                         );
+                    } else {
+                        incomingLanguage = recentLanguage.toLowerCase();
                     }
                 } else {
-                    boolean match = CollectionUtils.isNotEmpty(allowedLanguages) &&
-                            allowedLanguages.stream()
-                                    .map(String::toLowerCase)
-                                    .anyMatch(lang -> lang.equals(incomingLanguage.toLowerCase()));
-                    if (!match) {
-                        throw new ProjectCommonException(
-                                ResponseCode.languageRequired.getErrorCode(),
-                                ResponseCode.languageRequired.getErrorMessage(),
-                                ERROR_CODE
-                        );
+                    incomingLanguage = incomingLanguage.toLowerCase();
+                    if (MapUtils.isNotEmpty(languageMapV1)) {
+                        if (!languageMapV1.containsKey(incomingLanguage)) {
+                            throw new ProjectCommonException(
+                                    ResponseCode.languageRequired.getErrorCode(),
+                                    ResponseCode.languageRequired.getErrorMessage(),
+                                    ERROR_CODE
+                            );
+                        }
                     }
-                    map.put(JsonKey.LANGUAGE, incomingLanguage.toLowerCase());
                 }
-
+                map.put(JsonKey.LANGUAGE, incomingLanguage);
             }
         }
         List<Map<String, Object>> assessmentData =
@@ -217,12 +230,9 @@ public class ExtendedRequestValidator {
         }
     }
 
-    public static Boolean isProgramConsumptionAccepted(String courseId, String contentId) {
+    public static Boolean isProgramConsumptionAccepted(String courseCategory, String contentId, Boolean cumulativeTracking) {
         Boolean isProgram = false;
         try {
-            Map<String, Object> courseContent = getCourseContent(courseId);
-            String courseCategory = (String) courseContent.get("courseCategory");
-            Boolean cumulativeTracking = (Boolean) courseContent.get("cumulativeTracking");
             if (StringUtils.isBlank(courseCategory)) {
                 throw new ProjectCommonException(
                         ResponseCode.invalidCourseCategory.getErrorCode(),
@@ -238,12 +248,23 @@ public class ExtendedRequestValidator {
                 } else if (cumulativeTracking) {
                     Map<String, Object> resourceContent =  getCourseContent(contentId);
                     String contextCategory = (String) resourceContent.get(JsonKey.CONTEXT_CATEGORY);
-                    if (isCategoryAllowed(contextCategory)) {
+                    String primaryCategory = (String) resourceContent.get(JsonKey.PRIMARYCATEGORY);
+                    boolean allowed = false;
+                    if (StringUtils.isNotBlank(contextCategory)) {
+                        allowed = isCategoryAllowed(contextCategory);
+                    } else if (StringUtils.isNotBlank(primaryCategory)) {
+                        allowed = isPrimaryCategoryAllowed(primaryCategory);
+                    }
+                    if (allowed) {
                         isProgram = false;
                     } else {
                         isProgram = true;
                     }
-                    logger.info(null, "ContextCategory is details Id: " + contentId + ", category: " + contextCategory + ", isProgram: " + isProgram);
+                    logger.info(null,
+                            "ContextCategory is details Id: " + contentId +
+                                    ", contextCategory=" + contextCategory +
+                                    ", primaryCategory=" + primaryCategory +
+                                    ", isProgram=" + isProgram);
                 }
             }
         } catch (Exception e) {
@@ -267,5 +288,51 @@ public class ExtendedRequestValidator {
         String categoriesList = ProjectUtil.getConfigValue(JsonKey.PROGRAM_CATEGORIES);
         Set<String> programCategories = new HashSet<>(Arrays.asList(categoriesList.split(",\\s*")));
         return programCategories.contains(category);
+    }
+
+    private static Map<String, Object> fetchEnrolmentData(String userId, String courseId, String batchId, Request request) {
+
+        Map<String, Object> filters = new HashMap<>();
+        filters.put(JsonKey.USER_ID_KEY, userId);
+        filters.put(JsonKey.COURSE_ID_KEY, courseId);
+        filters.put(JsonKey.BATCH_ID_KEY, batchId);
+
+        Response response = cassandraOperation.getRecords(
+                request.getRequestContext(),
+                enrolmentDBInfo.getKeySpace(),
+                enrolmentDBInfo.getTableName(),
+                filters,
+                null
+        );
+
+        List<Map<String, Object>> resultList = (List<Map<String, Object>>)
+                response.getResult().getOrDefault(JsonKey.RESPONSE, new ArrayList<>());
+
+        if (resultList.isEmpty()) {
+            throw new ProjectCommonException(
+                    ResponseCode.invalidRequestData.getErrorCode(),
+                    String.format(
+                            "Enrolment not found for user: %s, course: %s, batch: %s",
+                            userId, courseId, batchId
+                    ),
+                    ERROR_CODE
+            );
+        }
+
+        Map<String, Object> enrolmentData = resultList.get(0);
+
+        String language = (String) request.getRequest().get(JsonKey.LANGUAGE);
+        if (StringUtils.isBlank(language)) {
+            language = (String) enrolmentData.get(JsonKey.RECENT_LANGUAGE);
+            request.getRequest().put(JsonKey.LANGUAGE, language);
+        }
+
+        return enrolmentData;
+    }
+
+    private static boolean isPrimaryCategoryAllowed(String category) {
+        String categoriesList = ProjectUtil.getConfigValue(JsonKey.ALLOWED_PRIMARY_CATEGORIES);
+        Set<String> allowed = new HashSet<>(Arrays.asList(categoriesList.split(",\\s*")));
+        return allowed.contains(category);
     }
 }

--- a/service/app/util/RequestValidator.java
+++ b/service/app/util/RequestValidator.java
@@ -1132,12 +1132,23 @@ public final class RequestValidator {
         } else if (cumulativeTracking) {
           Map<String, Object> resourceContent =  getCourseContent(contentId);
           String contextCategory = (String) resourceContent.get(JsonKey.CONTEXT_CATEGORY);
-          if (isCategoryAllowed(contextCategory)) {
+          String primaryCategory = (String) resourceContent.get(JsonKey.PRIMARYCATEGORY);
+          boolean allowed = false;
+          if (StringUtils.isNotBlank(contextCategory)) {
+            allowed = isCategoryAllowed(contextCategory);
+          } else if (StringUtils.isNotBlank(primaryCategory)) {
+            allowed = isPrimaryCategoryAllowed(primaryCategory);
+          }
+          if (allowed) {
             isProgram = false;
           } else {
             isProgram = true;
           }
-          logger.info(null, "ContextCategory is details Id: " + contentId + ", category: " + contextCategory + ", isProgram: " + isProgram);
+          logger.info(null,
+                  "Category check for contentId: " + contentId +
+                          ", contextCategory=" + contextCategory +
+                          ", primaryCategory=" + primaryCategory +
+                          ", isProgram=" + isProgram);
         }
       }
     } catch (Exception e) {
@@ -1160,6 +1171,12 @@ public final class RequestValidator {
     String categoriesList = ProjectUtil.getConfigValue(JsonKey.ALLOWED_RESOURCES_FOR_PROGRAM_STATUS_UPDATE);
     Set<String> allowedCategoryList = new HashSet<>(Arrays.asList(categoriesList.split(",\\s*")));
     return allowedCategoryList.contains(category);
+  }
+
+  private static boolean isPrimaryCategoryAllowed(String category) {
+    String categoriesList = ProjectUtil.getConfigValue(JsonKey.ALLOWED_PRIMARY_CATEGORIES);
+    Set<String> allowed = new HashSet<>(Arrays.asList(categoriesList.split(",\\s*")));
+    return allowed.contains(category);
   }
 
 }


### PR DESCRIPTION
* 4.8.27.2 dev v4 (#202)

* fix for the enrolment list issue (#196)

* added V2 tables for (#197)

courseEnrolmentActor: unEnroll
courseEnrolmentActor: enrollBlendedProgram
EventSetEnrolmentActor: enroll
EventSetEnrolmentActor: unEnroll
EventSetEnrolmentActor: enrollBlendedProgram
EventSetEnrolmentActor: bulkEnrolProgramV3
this APIs And reSolved comment review.



* added new user coursesdetails api (#198)

* fix for the enrolment list issue

* added new user coursesdetails api

* updated the changes

* added missing code from conflict

* updated user course details api to provide progress for program id (#201)

* fix for the enrolment list issue

* added new user coursesdetails api

* updated the changes

* added missing code from conflict

* added program content-progress details in user course details api

* updated getConsumption method

---------





* KB-11155: Learner portal > Multilingual course > Content progress read API does not return language specific progress if content is not consumed in one of the language



* Cbrelease 4.8.27.2 (#206) (#208)

* Bug has resolved for enrolling the curated Program with course.

* Changed access_setting_rules to access_setting_rules_v2 And solved to enroll the moderate course and program.

---------




* KB-11221 Increased the cassandra connection configuration

* KB-11224  commiting for course admin enroll V2 && program admin enroll v2 && OpenProgram enroll V2 && Event enroll v2 (#211) (#212)

* commiting for course admin enroll V2 && program admin enroll v2 && OpenProgram enroll V2 && Event enroll v2

* commiting for course admin enroll V2 && program admin enroll v2 && OpenProgram enroll V2 && Event enroll v2

---------




* changing V2 to V3 for event enroll API which is internally pointing course enroll. (#213)



* KB-11224 just added end point to RequestInterceptor to avoid the auth (#215) (#219)




* 4.8.27.2 dev v9 (#225)

* fix for the content state update issue (#220)

* KB-11245 The email notification triggered and the course name is not … (#222)

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix added null check for recentLanguage (#224)

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix added null check for recentLanguage

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix added null check for recentLanguage

---------




* 4.8.27.2 dev v9 (#226)

* fix for the content state update issue (#220)

* KB-11245 The email notification triggered and the course name is not … (#222)

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix added null check for recentLanguage (#224)

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix added null check for recentLanguage

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix added null check for recentLanguage

* Fix/content read (#221)

* fix: derive language from recent_language if missing

* fix(content-state-read): handle language resolution for multilingual courses

* fix(content-state-read): worked on code review comments

---------





* fix(content-state-read): handle language resolution for multilingual courses (#227)

* KB-10798 fix(content-state-update): handle language resolution for mu… (#234)

* KB-10798 fix(content-state-update): handle language resolution for multilingual courses

* KB-10798 fix(content-state-update): handle language resolution for multilingual courses

* Update ExtendedRequestValidator.java (#235)

* KB-11294:Content progress update for marking offline attendance (#236)

* KB-11294 : added validation in Extendedrequestvalidator  (#237)

* KB-11294:Content progress update for marking offline attendance

* KB-11294:Content progress update for marking offline attendance

* KB-11294: corrected config values  (#239) (#240)

* KB-11294:Content progress update for marking offline attendance

* KB-11294:Content progress update for marking offline attendance

* KB-11294:Corrected config value

* KB-11294:Corrected config value



* KB-11313 just added true for isCourse and isBlendedProgram (#242) (#243)

* KB-11224 just added end point to RequestInterceptor to avoid the auth

* KB-11313 just added true for isCourse and isBlendedProgram

---------




* 4.8.27.2 merge v1 (#247)

* 4.8.27.2 dev v4 (#202)

* fix for the enrolment list issue (#196)

* added V2 tables for (#197)

courseEnrolmentActor: unEnroll
courseEnrolmentActor: enrollBlendedProgram
EventSetEnrolmentActor: enroll
EventSetEnrolmentActor: unEnroll
EventSetEnrolmentActor: enrollBlendedProgram
EventSetEnrolmentActor: bulkEnrolProgramV3
this APIs And reSolved comment review.



* added new user coursesdetails api (#198)

* fix for the enrolment list issue

* added new user coursesdetails api

* updated the changes

* added missing code from conflict

* updated user course details api to provide progress for program id (#201)

* fix for the enrolment list issue

* added new user coursesdetails api

* updated the changes

* added missing code from conflict

* added program content-progress details in user course details api

* updated getConsumption method

---------





* KB-11155: Learner portal > Multilingual course > Content progress read API does not return language specific progress if content is not consumed in one of the language



* Cbrelease 4.8.27.2 (#206) (#208)

* Bug has resolved for enrolling the curated Program with course.

* Changed access_setting_rules to access_setting_rules_v2 And solved to enroll the moderate course and program.

---------




* KB-11221 Increased the cassandra connection configuration

* KB-11224  commiting for course admin enroll V2 && program admin enroll v2 && OpenProgram enroll V2 && Event enroll v2 (#211) (#212)

* commiting for course admin enroll V2 && program admin enroll v2 && OpenProgram enroll V2 && Event enroll v2

* commiting for course admin enroll V2 && program admin enroll v2 && OpenProgram enroll V2 && Event enroll v2

---------




* changing V2 to V3 for event enroll API which is internally pointing course enroll. (#213)



* KB-11224 just added end point to RequestInterceptor to avoid the auth (#215) (#219)




* 4.8.27.2 dev v9 (#225)

* fix for the content state update issue (#220)

* KB-11245 The email notification triggered and the course name is not … (#222)

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix added null check for recentLanguage (#224)

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix added null check for recentLanguage

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix added null check for recentLanguage

---------




* 4.8.27.2 dev v9 (#226)

* fix for the content state update issue (#220)

* KB-11245 The email notification triggered and the course name is not … (#222)

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix added null check for recentLanguage (#224)

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix added null check for recentLanguage

* KB-11245 The email notification triggered and the course name is not in a enrolled language issue fix added null check for recentLanguage

* Fix/content read (#221)

* fix: derive language from recent_language if missing

* fix(content-state-read): handle language resolution for multilingual courses

* fix(content-state-read): worked on code review comments

---------





* fix(content-state-read): handle language resolution for multilingual courses (#227)

* KB-10798 fix(content-state-update): handle language resolution for mu… (#234)

* KB-10798 fix(content-state-update): handle language resolution for multilingual courses

* KB-10798 fix(content-state-update): handle language resolution for multilingual courses

* Update ExtendedRequestValidator.java (#235)

* KB-11294:Content progress update for marking offline attendance (#236)

* KB-11294 : added validation in Extendedrequestvalidator  (#237)

* KB-11294:Content progress update for marking offline attendance

* KB-11294:Content progress update for marking offline attendance

* KB-11294: corrected config values  (#239) (#240)

* KB-11294:Content progress update for marking offline attendance

* KB-11294:Content progress update for marking offline attendance

* KB-11294:Corrected config value

* KB-11294:Corrected config value



* KB-11313 just added true for isCourse and isBlendedProgram (#242) (#243)

* KB-11224 just added end point to RequestInterceptor to avoid the auth

* KB-11313 just added true for isCourse and isBlendedProgram

---------




---------










* KB-11334 fix: show enrolled courses without progress in My Learning list (#245) (#249)



---------

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java-11, play2-2.7.2, scala-2.11, redis-5.0.3
* Hardware versions: 2 CPU / 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

