### PR TITLE
4.8.28 dev v3 resolved (#274)

### DIFF
--- a/course-mw/course-actors-common/pom.xml
+++ b/course-mw/course-actors-common/pom.xml
@@ -156,6 +156,12 @@
             <version>0.0.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.github.ben-manes.caffeine/caffeine -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.2.2</version>
+        </dependency>
     </dependencies>
 	<build>
 		<sourceDirectory>${basedir}/src/main/java</sourceDirectory>

--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/BatchCacheHandlerV2.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/BatchCacheHandlerV2.java
@@ -1,0 +1,96 @@
+package org.sunbird.learner.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.sunbird.cache.util.RedisCacheUtil;
+import org.sunbird.common.models.response.Response;
+import org.sunbird.common.models.util.JsonKey;
+import org.sunbird.common.models.util.LoggerUtil;
+import org.sunbird.common.models.util.PropertiesCache;
+import org.sunbird.cassandra.CassandraOperation;
+import org.sunbird.helper.ServiceFactory;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BatchCacheHandlerV2 {
+
+    private static BatchCacheHandlerV2 instance;
+
+    private LoggerUtil logger = new LoggerUtil(BatchCacheHandlerV2.class);
+    private CassandraOperation cassandraOperation = ServiceFactory.getInstance();
+    private Cache<String, Map<String, Object>> batchCache;
+
+    private BatchCacheHandlerV2() {
+        long ttlMinutes = Long.parseLong(PropertiesCache.getInstance().getProperty("BATCH_CACHE_TTL_MINUTES"));
+        long maxSize = Long.parseLong(PropertiesCache.getInstance().getProperty("BATCH_CACHE_MAX_SIZE"));
+
+       batchCache  = Caffeine.newBuilder()
+                .maximumSize(maxSize)
+                .expireAfterWrite(Duration.ofMinutes(ttlMinutes))
+                .recordStats()
+                .build();
+    }
+
+    public static BatchCacheHandlerV2 getInstance() {
+        if (instance == null) {
+            synchronized (BatchCacheHandlerV2.class) {
+                if (instance == null) {
+                    instance = new BatchCacheHandlerV2();
+                }
+            }
+        }
+        return instance;
+    }
+
+    public Map<String, Object> getContent(String batchId, String courseId) throws Exception {
+        Map<String, Object> content = batchCache.getIfPresent(batchId);
+        if (content != null) {
+            return content;
+        }
+
+        logger.info(null, "BatchCacheHandlerV2:getContent: Cache miss. Fetching from Cassandra for id: " + batchId);
+
+        Map<String, Object> primaryKey = new HashMap<>();
+        primaryKey.put(JsonKey.COURSE_ID, courseId);
+        primaryKey.put(JsonKey.BATCH_ID, batchId);
+
+        Response response = cassandraOperation.getRecordByIdentifier(
+                null,
+                "sunbird_courses",
+                "course_batch",
+                primaryKey,
+                null
+        );
+
+        if (response != null && response.getResult() != null) {
+            Object resultObj = response.getResult().get("response");
+
+            if (resultObj instanceof List) {
+                List<?> responseList = (List<?>) resultObj;
+                if (!responseList.isEmpty() && responseList.get(0) instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> fetchedContent = (Map<String, Object>) responseList.get(0);
+                    if (fetchedContent != null && !fetchedContent.isEmpty()) {
+                        batchCache.put(batchId, fetchedContent);
+                        return fetchedContent;
+                    } else {
+                        logger.info(null, "BatchCacheHandlerV2:getContent: Empty content for batchId: " + batchId);
+                    }
+                } else {
+                    logger.info(null, "BatchCacheHandlerV2:getContent: Unexpected response format for batchId: " + batchId);
+                }
+            } else {
+                logger.info(null, "BatchCacheHandlerV2:getContent: Response object is not a list for batchId: " + batchId);
+            }
+        } else {
+            logger.info(null, "BatchCacheHandlerV2:getContent: Null response or result from Cassandra for batchId: " + batchId);
+        }
+
+        return null;
+    }
+}

--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/ContentCacheHandlerV2.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/ContentCacheHandlerV2.java
@@ -1,22 +1,34 @@
 package org.sunbird.learner.util;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.sunbird.cache.util.RedisCacheUtil;
 import org.sunbird.common.models.util.JsonKey;
 import org.sunbird.common.models.util.LoggerUtil;
 import org.sunbird.common.models.util.PropertiesCache;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.Map;
 
 public class ContentCacheHandlerV2 {
-    private Map<String, CachedContent> contentMap = new ConcurrentHashMap<>();
     private static ContentCacheHandlerV2 instance;
-    private RedisCacheUtil redisCacheUtil = new RedisCacheUtil();
     private LoggerUtil logger = new LoggerUtil(ContentCacheHandlerV2.class);
-    private static final long LOCAL_TTL_MILLIS = 30 * 60 * 1000; // 30 minutes
+    private RedisCacheUtil redisCacheUtil = new RedisCacheUtil();
+
+    private final Cache<String, Map<String, Object>> contentCache;
+    private ContentCacheHandlerV2() {
+        long ttlMinutes = Long.parseLong(PropertiesCache.getInstance().getProperty("CONTENT_CACHE_TTL_MINUTES"));
+        long maxSize = Long.parseLong(PropertiesCache.getInstance().getProperty("CONTENT_CACHE_MAX_SIZE"));
+
+        contentCache = Caffeine.newBuilder()
+                .maximumSize(maxSize)
+                .expireAfterWrite(Duration.ofMinutes(ttlMinutes))
+                .recordStats()
+                .build();
+    }
+
 
     public static ContentCacheHandlerV2 getInstance() {
         if (instance == null) {
@@ -30,62 +42,44 @@ public class ContentCacheHandlerV2 {
     }
 
     public Map<String, Object> getContent(String id) throws Exception {
-        CachedContent cached = contentMap.get(id);
-        if (cached != null && !cached.isExpired(LOCAL_TTL_MILLIS)) {
-            return cached.content;
-        }
+        Map<String, Object> content = contentCache.getIfPresent(id);
+        if (content != null) return content;
 
         logger.info(null, "ContentCacheHandlerV2:getContent: Reading content from Redis for id: " + id);
         int ttl = Integer.parseInt(PropertiesCache.getInstance().getProperty(JsonKey.CONTENT_TTL));
         String cacheResponse = redisCacheUtil.getUsingIndex(id, null, ttl, 0);
         ObjectMapper mapper = new ObjectMapper();
         if (cacheResponse != null && !cacheResponse.trim().isEmpty() && !cacheResponse.trim().equals("{}")) {
-            Map<String, Object> content = mapper.readValue(cacheResponse, new TypeReference<Map<String, Object>>() {
-            });
-            contentMap.put(id, new CachedContent(content));
+            content = mapper.readValue(cacheResponse, new TypeReference<Map<String, Object>>() {});
+            contentCache.put(id, content);
             return content;
-        } else {
-            logger.info(null, "ContentCacheHandlerV2:getContent: Content not found in Redis for id: " + id);
-            Map<String, Object> content = ContentUtil.getContentReadV3(id, null, null);
-            if (content != null && !content.isEmpty()) {
-                contentMap.put(id, new CachedContent(content));
-                return content;
-            }
         }
+        logger.info(null, "ContentCacheHandlerV2:getContent: Content not found in Redis for id: " + id);
+        content = ContentUtil.getContentReadV3(id, null, null);
+
+        if (content != null && !content.isEmpty()) {
+            contentCache.put(id, content);
+            redisCacheUtil.set(id, mapper.writeValueAsString(content), ttl);
+            return content;
+        }
+
         return null;
     }
 
-    public Map<String, Object> getExternalContent(String id) {
-        CachedContent cached = contentMap.get(id);
-        if (cached != null && !cached.isExpired(LOCAL_TTL_MILLIS)) {
-            return cached.content;
-        }
+    public Map<String, Object> getExternalContent(String id) throws Exception {
+        Map<String, Object> content = contentCache.getIfPresent(id);
+        if (content != null) return content;
+
         Map<String, Object> fetched = ContentUtil.getAllExternalContent(
-                Arrays.asList(id),
+                java.util.Arrays.asList(id),
                 Integer.parseInt(PropertiesCache.getInstance().getProperty(JsonKey.PAGE_SIZE_CONTENT_FETCH))
         );
 
         if (fetched != null && !fetched.isEmpty()) {
-            contentMap.put(id, new CachedContent((Map<String, Object>) fetched.get(id)));
-            return (Map<String, Object>) fetched.get(id);
+            Map<String, Object> data = (Map<String, Object>) fetched.get(id);
+            contentCache.put(id, data);
+            return data;
         }
         return null;
-    }
-
-    /**
-     * New sub class to hold the data and TTL value.
-     */
-    private static class CachedContent {
-        Map<String, Object> content;
-        long cachedTimeMillis;
-
-        CachedContent(Map<String, Object> content) {
-            this.content = content;
-            this.cachedTimeMillis = System.currentTimeMillis();
-        }
-
-        boolean isExpired(long ttlMillis) {
-            return System.currentTimeMillis() - cachedTimeMillis > ttlMillis;
-        }
     }
 }

--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/SchedulerManager.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/SchedulerManager.java
@@ -23,7 +23,7 @@ public class SchedulerManager {
     service.scheduleWithFixedDelay(new PageCacheLoaderService(), 0, PAGE_DATA_TTL, TimeUnit.HOURS);
     //Let's try to load at the run time from Redis -- these schedules are causing heavy load on ES.
     //service.scheduleWithFixedDelay(new ContentCacheHandler(), 0, 15, TimeUnit.MINUTES);
-    service.scheduleWithFixedDelay(new BatchCacheHandler(), 0, 15, TimeUnit.MINUTES);
+    //service.scheduleWithFixedDelay(new BatchCacheHandler(), 0, 15, TimeUnit.MINUTES);
 
     logger.info(null, 
         "SchedulerManager:schedule: Started scheduler job for cache refresh.");

--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/ExtendedCourseEnrollmentActor.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/ExtendedCourseEnrollmentActor.scala
@@ -18,7 +18,7 @@ import org.sunbird.kafka.client.{InstructionEventGenerator, KafkaClient}
 import org.sunbird.learner.actors.course.dao.impl.ContentHierarchyDaoImpl
 import org.sunbird.learner.actors.coursebatch.dao.impl.{BatchUserDaoImpl, CourseBatchDaoImpl, UserCoursesDaoImpl}
 import org.sunbird.learner.actors.coursebatch.dao.{BatchUserDao, CourseBatchDao, UserCoursesDao}
-import org.sunbird.learner.util.{BatchCacheHandler, ContentCacheHandlerV2, ContentUtil, ExtendedUtil, JsonUtil, Util}
+import org.sunbird.learner.util.{BatchCacheHandlerV2, ContentCacheHandlerV2, ContentUtil, ExtendedUtil, JsonUtil, Util}
 import org.sunbird.models.batch.user.BatchUser
 import org.sunbird.models.course.batch.CourseBatch
 import org.sunbird.models.user.courses.UserCourses
@@ -638,18 +638,32 @@ class ExtendedCourseEnrollmentActor @Inject()(@Named("course-batch-notification-
     ContentCacheHandlerV2.getInstance().getExternalContent(courseId)
   }
 
-  def addBatchDetails(enrolmentList: util.List[util.Map[String, AnyRef]], request: Request,version:String): util.List[util.Map[String, AnyRef]] = {
-    val batchIds:java.util.List[String] = enrolmentList.map(e => e.getOrDefault(JsonKey.BATCH_ID, "").asInstanceOf[String]).distinct.filter(id => StringUtils.isNotBlank(id)).toList.asJava
-    val batchDetails = new java.util.ArrayList[java.util.Map[String, AnyRef]]();
-    val searchIdentifierMaxSize = Integer.parseInt(ProjectUtil.getConfigValue(JsonKey.SEARCH_IDENTIFIER_MAX_SIZE));
+  def addBatchDetails(enrolmentList: util.List[util.Map[String, AnyRef]], request: Request, version: String): util.List[util.Map[String, AnyRef]] = {
+
+    val batchIds: java.util.List[String] = enrolmentList
+      .map(e => e.getOrDefault(JsonKey.BATCH_ID, "").asInstanceOf[String])
+      .distinct
+      .filter(id => StringUtils.isNotBlank(id))
+      .toList
+      .asJava
+
+    val batchDetails = new java.util.ArrayList[java.util.Map[String, AnyRef]]()
+    val searchIdentifierMaxSize = Integer.parseInt(ProjectUtil.getConfigValue(JsonKey.SEARCH_IDENTIFIER_MAX_SIZE))
+
     if (JsonKey.VERSION_3.equalsIgnoreCase(version) &&
-      JsonKey.TRUE.equalsIgnoreCase(ProjectUtil.getConfigValue(JsonKey.ENROLLMENT_LIST_CACHE_BATCH_FETCH_ENABLED))){
-      logger.info(request.getRequestContext, "Retrieving batch details from the local cache");
-      for (i <- 0 to batchIds.size()-1) {
-        batchDetails.add(getBatchFrmLocalCache(batchIds.get(i)))
+      JsonKey.TRUE.equalsIgnoreCase(ProjectUtil.getConfigValue(JsonKey.ENROLLMENT_LIST_CACHE_BATCH_FETCH_ENABLED))) {
+
+      logger.info(request.getRequestContext, "Retrieving batch details from the local cache")
+
+      for (enrolment <- enrolmentList.asScala) {
+        val batchId = enrolment.getOrDefault(JsonKey.BATCH_ID, "").asInstanceOf[String]
+        val courseId = enrolment.getOrDefault(JsonKey.COURSE_ID, "").asInstanceOf[String]
+        if (StringUtils.isNotBlank(batchId) && StringUtils.isNotBlank(courseId)) {
+          batchDetails.add(getBatchFrmLocalCacheV2(batchId, courseId))
+        }
       }
-    }
-    else if (batchIds.size() > searchIdentifierMaxSize) {
+
+    } else if (batchIds.size() > searchIdentifierMaxSize) {
       for (i <- 0 to batchIds.size() by searchIdentifierMaxSize) {
         val batchIdsSubList: java.util.List[String] = batchIds.subList(i, Math.min(batchIds.size(), i + searchIdentifierMaxSize));
         batchDetails.addAll(searchBatchDetails(batchIdsSubList, request))
@@ -657,7 +671,7 @@ class ExtendedCourseEnrollmentActor @Inject()(@Named("course-batch-notification-
     } else {
       batchDetails.addAll(searchBatchDetails(batchIds, request))
     }
-    if(CollectionUtils.isNotEmpty(batchDetails)){
+    if (CollectionUtils.isNotEmpty(batchDetails)) {
       val batchMap = batchDetails.map(b => b.get(JsonKey.BATCH_ID).asInstanceOf[String] -> b).toMap
       enrolmentList.map(enrolment => {
         enrolment.put(JsonKey.BATCH, batchMap.getOrElse(enrolment.get(JsonKey.BATCH_ID).asInstanceOf[String], new java.util.HashMap[String, AnyRef]()))
@@ -678,14 +692,6 @@ class ExtendedCourseEnrollmentActor @Inject()(@Named("course-batch-notification-
     } else {
       new java.util.ArrayList[util.Map[String, AnyRef]]()
     }
-  }
-
-  def getBatchFrmLocalCache(batchId: String): java.util.Map[String, AnyRef] = {
-    val batchesMap = BatchCacheHandler.getBatchMap.asInstanceOf[java.util.Map[String, java.util.Map[String, AnyRef]]]
-    var batch = batchesMap.get(batchId)
-    if (batch == null || batch.size() < 1)
-      batch = BatchCacheHandler.getBatch(batchId)
-    batch
   }
 
   private def enrichCourseIdFromProgram(request: Request, courseIdList:  java.util.List[String]) = {
@@ -740,7 +746,7 @@ class ExtendedCourseEnrollmentActor @Inject()(@Named("course-batch-notification-
 
       // New logic: update contentStatus if recentLanguage is present and contentStatus is null
       val recentLanguage = enrolment.get("recent_language")
-      val contentStatus = enrolment.get("contentstatus")
+      val contentStatus = enrolment.get("contentStatus")
       val languageMapV1 = enrolment.get("langContentStatus").asInstanceOf[java.util.Map[String, AnyRef]]
 
       if (recentLanguage != null && (contentStatus == null || StringUtils.isBlank(contentStatus.toString)) && languageMapV1 != null) {
@@ -1327,4 +1333,20 @@ class ExtendedCourseEnrollmentActor @Inject()(@Named("course-batch-notification-
     }
     false;
   }
+
+  def getBatchFrmLocalCacheV2(batchId: String, courseId: String): java.util.Map[String, AnyRef] = {
+    try {
+      val batch = BatchCacheHandlerV2.getInstance().getContent(batchId, courseId)
+      if (batch != null && !batch.isEmpty) {
+        batch.asInstanceOf[java.util.Map[String, AnyRef]]
+      } else {
+        null
+      }
+    } catch {
+      case ex: Exception =>
+        logger.error(null, s"getBatchFrmLocalCacheV2: Exception while retrieving batch for batchId: $batchId and courseId: $courseId", ex)
+        null
+    }
+  }
+
 }

--- a/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/resources/externalresource.properties
+++ b/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/resources/externalresource.properties
@@ -252,3 +252,7 @@ notification_wrapper_api_host=http://cb-notification-wrapper-service:8081
 notification_wrapper_api_endpoint=/notifications/create
 content_read=/content/v4/read/
 blended_program_allowed_primary_categories=Offline Session,Course Assessment,Learning Resource,Practice Question Set
+BATCH_CACHE_TTL_MINUTES=30
+BATCH_CACHE_MAX_SIZE=100000
+CONTENT_CACHE_TTL_MINUTES=30
+CONTENT_CACHE_MAX_SIZE=100000


### PR DESCRIPTION
* KB-11349 fix: auto-enrol courses during bulk enrolment for invite-only programs (#252)

* Allow Learning Resources primary category for blended programs only (#255)

* Fix primaryCategory check for blended programs: allow Learning Resource (#262)

* Add config-driven allowed primary categories for Blended Program (#265)

* updating the proper field for contentStatus

* 4.8.27.2 caffeine cache (#268)

* KB-11223 - LMS Service - BatchCacheHandler Optimization

* Changes post testing

* KB-11223 Replaced ConcurrentHashMap with Caffeine cache for efficient in-memory storage

* KB-11223 Apply local cache and Caffeine optimization changes

* KB-11223 Apply local cache and Caffeine optimization changes

---------



* 4.8.27.2 caffeine cache (#271)

* KB-11223 refactor: remove Redis caching from batch lookup

* KB-11223 refactor: remove Redis caching from batch lookup

* Update ExtendedCourseEnrollmentActor.scala

---------

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java-11, play2-2.7.2, scala-2.11, redis-5.0.3
* Hardware versions: 2 CPU / 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

