### PR TITLE
KB-12210 | Fix for certificate for the retired moderated course is no…

### DIFF
--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/ContentCacheHandlerV2.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/ContentCacheHandlerV2.java
@@ -86,4 +86,33 @@ public class ContentCacheHandlerV2 {
         }
         return null;
     }
+
+    public Map<String, Object> getAdminContent(String id) throws Exception {
+        Map<String, Object> content = contentCache.getIfPresent(id);
+        if (content != null) return content;
+        int ttl = Integer.parseInt(PropertiesCache.getInstance().getProperty(JsonKey.CONTENT_TTL));
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            logger.info(null, "ContentCacheHandlerV2:getContent: Reading content from Redis for id: " + id);
+            String cacheResponse = redisCacheUtil.getUsingIndex(id, null, ttl, 0);
+            if (StringUtils.isNotBlank(cacheResponse) && !StringUtils.equals(StringUtils.trim(cacheResponse), "{}")) {
+                content = mapper.readValue(cacheResponse, new TypeReference<Map<String, Object>>() {
+                });
+                contentCache.put(id, content);
+                return content;
+            }
+        } catch (Exception e) {
+            logger.error(null, "ContentCacheHandlerV2:getContent: Error while reading content from Redis for id: " + id, e);
+        }
+        logger.info(null, "ContentCacheHandlerV2:getContent: Content not found in Redis for id: " + id);
+        content = ContentUtil.getAdminContentReadV4(id, null, null);
+
+        if (content != null && !content.isEmpty()) {
+            contentCache.put(id, content);
+            redisCacheUtil.set(id, mapper.writeValueAsString(content), ttl);
+            return content;
+        }
+
+        return null;
+    }
 }

--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/ContentUtil.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/ContentUtil.java
@@ -716,4 +716,40 @@ public final class ContentUtil {
         }
         return emailResponseList;
     }
+
+    public static Map<String, Object> getAdminContentReadV4(String collectionId, List<String> fields,
+                                                            Map<String, String> allHeaders) {
+        logger.info(null, "ContentUtil::getAdminContentRead:: Reading content using REST API." + collectionId);
+        try {
+            Map<String, String> headers = new HashMap<>();
+            if (allHeaders != null && allHeaders.containsKey(JsonKey.X_AUTH_USER_ORG_ID)) {
+                headers.put(JsonKey.X_AUTH_USER_ORG_ID, allHeaders.get(JsonKey.X_AUTH_USER_ORG_ID));
+            }
+            String baseContentReadUrl =
+                    ProjectUtil.getConfigValue(JsonKey.EKSTEP_BASE_URL)
+                            + ProjectUtil.getConfigValue(JsonKey.EKSTEP_ADMIN_CONTENT_READ_URL)
+                            + collectionId;
+            logger.info(null, "ContentUtil::getAdminContentV4:: baseContentReadUrl: " + baseContentReadUrl);
+            if (CollectionUtils.isNotEmpty(fields)) {
+                StringJoiner apiFields = new StringJoiner(",");
+                for (String item : fields) {
+                    apiFields.add(item);
+                }
+                if (StringUtils.isNotBlank(apiFields.toString())) {
+                    baseContentReadUrl = baseContentReadUrl + "?fields=" + apiFields;
+                }
+            }
+            String response = HttpUtil.sendGetRequest(baseContentReadUrl, headers);
+            if (response != null && !response.isEmpty()) {
+                Map<String, Object> data = mapper.readValue(response, Map.class);
+                if (JsonKey.OK.equalsIgnoreCase((String) data.get(JsonKey.RESPONSE_CODE))) {
+                    Map<String, Object> contentResult = (Map<String, Object>) data.get(JsonKey.RESULT);
+                    return (Map<String, Object>) contentResult.get(JsonKey.CONTENT);
+                }
+            }
+        } catch (Exception e) {
+            logger.error(null, "User don't have access to this programId " + collectionId, e);
+        }
+        return new HashMap<>();
+    }
 }

--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/ExtendedCourseEnrollmentActor.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/ExtendedCourseEnrollmentActor.scala
@@ -683,7 +683,11 @@ class ExtendedCourseEnrollmentActor @Inject()(@Named("course-batch-notification-
   }
 
   def getCourseContent(courseId: String): java.util.Map[String, AnyRef] = {
-    ContentCacheHandlerV2.getInstance().getContent(courseId)
+    if (StringUtils.isNotEmpty(courseId) && courseId.endsWith("_rc")) {
+      ContentCacheHandlerV2.getInstance().getAdminContent(courseId)
+    } else {
+      ContentCacheHandlerV2.getInstance().getContent(courseId)
+    }
   }
 
   def getExternalCourseContent(courseId: String): java.util.Map[String, AnyRef] = {

--- a/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
+++ b/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
@@ -1296,6 +1296,7 @@ public final class JsonKey {
   public static final String EXPIRED_BATCH_ALLOWED_ROOT_FIELDS = "expired_batch_allowed_root_fields";
   public static final String EXPIRED_BATCH_ALLOWED_BATCH_ATTRIBUTES_FIELDS = "expired_batch_allowed_attribute_fields";
   public static final String IS_EXPIRED = "isExpired";
+  public static final String EKSTEP_ADMIN_CONTENT_READ_URL = "sunbird_admin_content_read_api";
 
     private JsonKey() {}
 }

--- a/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/resources/externalresource.properties
+++ b/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/resources/externalresource.properties
@@ -267,3 +267,4 @@ consumption_response_fields=lastAccessTime,contentId,language,batchId,progressde
 sunbird_batch_update_notification_enabled=true
 expired_batch_allowed_root_fields=id,courseId,batchAttributes
 expired_batch_allowed_attribute_fields=instructorsUserId,instructors
+sunbird_admin_content_read_api=/content/v4/admin/read/


### PR DESCRIPTION
…… (#328)

* KB-12210 | Fix for certificate for the retired moderated course is not visible on the portal.

* KB-12210 | Fix for certificate for the retired moderated course is not visible on the portal.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java-11, play2-2.7.2, scala-2.11, redis-5.0.3
* Hardware versions: 2 CPU / 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

