### PR TITLE
KB-14009 | BE | Blended Program Enhancements | Learner TOC Page enhan…

### DIFF
--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/actors/coursebatch/dao/UserCoursesDao.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/actors/coursebatch/dao/UserCoursesDao.java
@@ -86,4 +86,6 @@ public interface UserCoursesDao {
   List<UserCourses> extendedReadAllV2(RequestContext requestContext, String userId, String courseId);
 
   Map<String, Object> getEventParticipantsForExternalTraining(RequestContext requestContext, Map<String, Object> request);
+
+  long countActiveParticipants(RequestContext requestContext, String batchId);
 }

--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/actors/coursebatch/dao/impl/UserCoursesDaoImpl.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/actors/coursebatch/dao/impl/UserCoursesDaoImpl.java
@@ -545,4 +545,26 @@ public class UserCoursesDaoImpl implements UserCoursesDao {
     return offsetFromRequest;
   }
 
+  @Override
+  public long countActiveParticipants(RequestContext requestContext, String batchId) {
+    logger.info(requestContext, "UserCourseDao:: countActiveParticipants:: batchId=" + batchId);
+    try {
+      Response response = cassandraOperation.getRecordsByPropertiesWithoutFiltering(
+          requestContext, KEYSPACE_NAME, ENROLMENT_BATCH_LOOKUP,
+          JsonKey.BATCH_ID, batchId,
+          Arrays.asList(JsonKey.ACTIVE));
+      List<Map<String, Object>> rows = (List<Map<String, Object>>) response.get(JsonKey.RESPONSE);
+      if (CollectionUtils.isEmpty(rows)) {
+        logger.info(requestContext, "UserCourseDao:: countActiveParticipants:: No rows found for batchId=" + batchId);
+        return 0L;
+      }
+      long count = rows.stream().filter(row -> Boolean.TRUE.equals(row.get(JsonKey.ACTIVE))).count();
+      logger.info(requestContext, "UserCourseDao:: countActiveParticipants:: Active participant count for batchId=" + batchId + " is: " + count);
+      return count;
+    } catch (Exception e) {
+      logger.error(requestContext, "UserCourseDao:: countActiveParticipants:: Failed to count active participants for batchId=" + batchId, e);
+      return 0L;
+    }
+  }
+
 }

--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/ExtendedCourseEnrollmentActor.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/ExtendedCourseEnrollmentActor.scala
@@ -49,6 +49,10 @@ class ExtendedCourseEnrollmentActor @Inject()(@Named("course-batch-notification-
   val statusMap: Map[String, Int] = Map("In-Progress" -> 1, "Completed" -> 2, "Not-Started" -> 0)
   val redisCollectionIndex = if (StringUtils.isNotBlank(ProjectUtil.getConfigValue("redis_collection_index")))
     (ProjectUtil.getConfigValue("redis_collection_index")).toInt else 10
+  private val bpBatchStatsCacheIndex = if (StringUtils.isNotBlank(ProjectUtil.getConfigValue("bp_batch_stats_cache_index")))
+    ProjectUtil.getConfigValue("bp_batch_stats_cache_index").toInt else 2
+  private val bpBatchStatsCacheTtl = if (StringUtils.isNotBlank(ProjectUtil.getConfigValue("bp_batch_stats_cache_ttl")))
+    ProjectUtil.getConfigValue("bp_batch_stats_cache_ttl").toInt else 14400
   private val externalCourseEnrolDbInfo = Util.dbInfoMap.get(JsonKey.EXTERNAL_COURSES_ENROLMENT_DB)
   private val cassandraOperation = ServiceFactory.getInstance
   val jsonFields = Set[String]("lrcProgressDetails")
@@ -1088,6 +1092,7 @@ class ExtendedCourseEnrollmentActor @Inject()(@Named("course-batch-notification-
       val topic = ProjectUtil.getConfigValue("kafka_user_enrolment_event_topic")
       InstructionEventGenerator.createCourseEnrolmentEvent("", topic, dataMap)
       cacheUtil.delete(getCacheBatchKey(batchId))
+      incrementBatchApprovedCount(batchId, request.getRequestContext)
     } else {
       ProjectCommonException.throwClientErrorException(ResponseCode.accessDeniedToEnrolOrUnenrolCourse, courseId)
     }
@@ -1190,6 +1195,7 @@ class ExtendedCourseEnrollmentActor @Inject()(@Named("course-batch-notification-
         val dataBatch: util.Map[String, AnyRef] = createBatchUserMapping(batchId, userId, batchUserData)
         val data: java.util.Map[String, AnyRef] = createUserEnrolmentMap(userId, programId, batchId, enrolmentData, request.getContext.getOrDefault(JsonKey.REQUEST_ID, "").asInstanceOf[String], request.getRequestContext, courseLanguage)
         upsertEnrollment(userId, programId, batchId, data, dataBatch, (null == enrolmentData), request.getRequestContext)
+        incrementBatchApprovedCount(batchId, request.getRequestContext)
         logger.info(request.getRequestContext, "ProgramEnrolmentActor :: enroll :: Deleting redis for key " + getCacheKey(userId))
         cacheUtil.delete(getCacheKey(userId))
         generatePreProcessorKafkaEvent(request, batchId, programId, userId)
@@ -1610,6 +1616,37 @@ class ExtendedCourseEnrollmentActor @Inject()(@Named("course-batch-notification-
       case e: Exception =>
         logger.warn(null, s"Failed to fetch badge count for userId $userId: ${e.getMessage}", e)
         -1
+    }
+  }
+
+  /**
+   * Lazy-initialises and increments the "approved" field in the blended-program batch enrollment
+   * stats Redis hash. Key: bp:batch:enrollment:stats:{batchId}, field: "approved".
+   * Must be called after upsertEnrollment so the Cassandra row is already visible.
+   * Uses HSETNX for atomic lazy-init from Cassandra active-participant count on first write;
+   * subsequent writes use HINCRBY directly.
+   */
+  private def incrementBatchApprovedCount(batchId: String, requestContext: RequestContext): Unit = {
+    logger.info(requestContext, s"BatchStats: incrementBatchApprovedCount :: start :: batchId=$batchId")
+    val key = s"bp:batch:enrollment:stats:$batchId"
+    val jedis = cacheUtil.getConnection(bpBatchStatsCacheIndex)
+    try {
+      if (!jedis.hexists(key, "approved")) {
+        // Cache miss: initialise from Cassandra enrollment table (source of truth).
+        // Called post-upsert so the count includes the current user;
+        // subtract 1 so the unconditional HINCRBY below accounts for this enrollment.
+        val baseCount = Math.max(0L, userCoursesDao.countActiveParticipants(requestContext, batchId) - 1L)
+        jedis.hsetnx(key, "approved", baseCount.toString)
+        jedis.expire(key, bpBatchStatsCacheTtl.toLong)
+        logger.info(requestContext, s"BatchStats: Initialised approved cache for batchId=$batchId baseCount=$baseCount ttl=${bpBatchStatsCacheTtl}s")
+      }
+      val newCount = jedis.hincrBy(key, "approved", 1L)
+      logger.info(requestContext, s"BatchStats: Incremented approved count for batchId=$batchId newApprovedCount=$newCount")
+    } catch {
+      case e: Exception =>
+        logger.error(requestContext, s"BatchStats: Failed to update approved count for batchId=$batchId", e)
+    } finally {
+      jedis.close()
     }
   }
 }


### PR DESCRIPTION
…cement#179 (#373)

feat: track BP batch approved count in Redis cache on enrolment

Adds countActiveParticipants to UserCoursesDao and incrementBatchApprovedCount in ExtendedCourseEnrollmentActor to maintain an approved participant counter in Redis (lazy-init from Cassandra, incremented on each enrolment approval). Cache index and TTL are config-driven with sensible defaults.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java-11, play2-2.7.2, scala-2.11, redis-5.0.3
* Hardware versions: 2 CPU / 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

