### PR TITLE
4.8.39.1 kar 1195

### DIFF
--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/actors/event/EventManagementActor.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/actors/event/EventManagementActor.java
@@ -301,7 +301,7 @@ public class EventManagementActor extends BaseActor {
                 eventsEnrolled++;
 
                 String lrcProgressDetails = (String) eventDetails.get(JsonKey.LRC_PROGRESS_DETAILS);
-                if (StringUtils.isNotBlank(lrcProgressDetails)) {
+                if (eventDetails.get(JsonKey.ISSUED_CERTIFICATES) != null && StringUtils.isNotBlank(lrcProgressDetails)) {
                     try {
                         JsonNode progressJson = mapper.readTree(lrcProgressDetails);
                         if (progressJson.hasNonNull(JsonKey.DURATION)) {

--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/ExtendedCourseEnrollmentActor.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/ExtendedCourseEnrollmentActor.scala
@@ -618,13 +618,10 @@ class ExtendedCourseEnrollmentActor @Inject()(@Named("course-batch-notification-
           coursesInProgress += 1
         }
       } else {
-        var hoursSpentOnCourses: Int = 0
-        val certificatesIssue: java.util.ArrayList[util.Map[String, AnyRef]] = courseDetails.get(JsonKey.ISSUED_CERTIFICATES).asInstanceOf[java.util.ArrayList[util.Map[String, AnyRef]]]
+        val certificatesIssue = courseDetails.get(JsonKey.ISSUED_CERTIFICATES).asInstanceOf[java.util.ArrayList[util.Map[String, AnyRef]]]
         if (certificatesIssue.nonEmpty) {
-          if (null != courseContent.get(JsonKey.DURATION)) {
-            hoursSpentOnCourses = courseContent.get(JsonKey.DURATION).asInstanceOf[String].toInt
-          }
-          hoursSpentOnCompletedCourses += hoursSpentOnCourses
+          val courseCategory = courseContent.getOrDefault(JsonKey.COURSECATEGORY, "").asInstanceOf[String]
+          hoursSpentOnCompletedCourses += calculateCategorySpecificDuration(courseCategory, courseContent, courseDetails, actorMessage)
           certificateIssued += 1
         }
       }


### PR DESCRIPTION
-> event's learning hours should only be counted if issued certificate field is not null for user event summary API

-> and re-added new learning hours method changes to current method